### PR TITLE
Expose clsid member

### DIFF
--- a/file.go
+++ b/file.go
@@ -228,6 +228,10 @@ func (f *File) Modified() time.Time {
 	return f.modify.Time()
 }
 
+func (f *File) GetClsID() types.Guid {
+	return f.directoryEntryFields.clsid
+}
+
 // Read this directory entry
 // Returns 0, io.EOF if no stream is available (i.e. for a storage object)
 func (f *File) Read(b []byte) (int, error) {


### PR DESCRIPTION
The `clsid` value found under the `directoryEntryFields` for a `File` struct can be very useful for assessing file type, amongst other things. This information would be very useful to expose to users. 

I therefore added a function `GetClsID` to the `File` struct to allow retrieval of said info.

Thanks :)